### PR TITLE
Update example to fetch roles and permissions in parallel

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -65,11 +65,11 @@ Vue.use(LaravelPermissions);
 ### Step 5: Set permissions and roles
 
 ```js
-const { data: permissions } = await axios.get('/api/permissions');
-const { data: roles } = await axios.get('/api/roles');
+const { data: permissions } = axios.get('/api/permissions');
+const { data: roles } = axios.get('/api/roles');
 
-this.$laravel.setPermissions(permissions);
-this.$laravel.setRoles(roles);
+this.$laravel.setPermissions(await permissions);
+this.$laravel.setRoles(await roles);
 ```
 
 ### Finish!

--- a/examples/README.md
+++ b/examples/README.md
@@ -65,11 +65,14 @@ Vue.use(LaravelPermissions);
 ### Step 5: Set permissions and roles
 
 ```js
-const { data: permissions } = axios.get('/api/permissions');
-const { data: roles } = axios.get('/api/roles');
+const permissionsRequest = axios.get('/api/permissions');
+const rolesRequest = axios.get('/api/roles');
 
-this.$laravel.setPermissions(await permissions);
-this.$laravel.setRoles(await roles);
+const { data: permissions } = await permissionsRequest;
+const { data: roles } = await rolesRequest;
+
+this.$laravel.setPermissions(permissions);
+this.$laravel.setRoles(roles);
 ```
 
 ### Finish!

--- a/examples/resources/js/components/ExampleComponent.vue
+++ b/examples/resources/js/components/ExampleComponent.vue
@@ -17,11 +17,11 @@
 <script>
     export default {
         async created() {
-            const { data: permissions } = await axios.get('/api/permissions');
-            const { data: roles } = await axios.get('/api/roles');
+            const { data: permissions } = axios.get('/api/permissions');
+            const { data: roles } = axios.get('/api/roles');
 
-            this.$laravel.setPermissions(permissions);
-            this.$laravel.setRoles(roles);
+            this.$laravel.setPermissions(await permissions);
+            this.$laravel.setRoles(await roles);
         }
     }
 </script>

--- a/examples/resources/js/components/ExampleComponent.vue
+++ b/examples/resources/js/components/ExampleComponent.vue
@@ -17,11 +17,14 @@
 <script>
     export default {
         async created() {
-            const { data: permissions } = axios.get('/api/permissions');
-            const { data: roles } = axios.get('/api/roles');
+            const permissionsRequest = axios.get('/api/permissions');
+            const rolesRequest = axios.get('/api/roles');
 
-            this.$laravel.setPermissions(await permissions);
-            this.$laravel.setRoles(await roles);
+            const { data: permissions } = await permissionsRequest;
+            const { data: roles } = await rolesRequest;
+
+            this.$laravel.setPermissions(permissions);
+            this.$laravel.setRoles(roles);
         }
     }
 </script>


### PR DESCRIPTION
This is extremely minor but in your example the roles request won't fire until the permissions response has returned.