### PR TITLE
:bug: To remove el use remove() instead of removeChild() from parent,…

### DIFF
--- a/dist/vue-gates.js
+++ b/dist/vue-gates.js
@@ -296,7 +296,7 @@
       if (!isValid) {
         if (isEmpty(binding.modifiers)) {
           // Remove DOM Element
-          el.parentNode.removeChild(el);
+          el.remove();
         } else {
           // Set attributes to DOM element
           Object.assign(el, binding.modifiers);


### PR DESCRIPTION
… fixing issues where parent gets removed earlier

This is in relation to Issue: #49 

For my project this is fixing the issues, I do not really know why this library uses the parent to remove the element already in the variable "el". If there is no specific reason I think remove() is a safer implementation, solving issues where the parent is not accessible.